### PR TITLE
Add linting to pipeline, add as requirement for other parts of pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,9 +9,39 @@ on:
       - main
 
 jobs:
+  # Linting job using Flake8
+  CodeLinting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Flake8
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Run Flake8 Linting
+        run: |
+          flake8 . --count --show-source --statistics --output-file=flake8-report.txt || true
+
+      - name: Upload Linting Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: flake8-lint-report
+          path: flake8-report.txt
+          if-no-files-found: warn
+
   # Test job to run unittest
   PyTests:
     runs-on: ubuntu-latest
+    needs: CodeLinting  # Ensures linting runs before tests
 
     steps:
       - name: Checkout code
@@ -34,6 +64,7 @@ jobs:
   # Identification and Authorisation tests using Bandit
   IdentifcationAuthorisationTests:
     runs-on: ubuntu-latest
+    needs: PyTests  # Ensures tests run before security scans
 
     steps:
       - name: Checkout code
@@ -53,7 +84,7 @@ jobs:
         run: |
           bandit -r . --output bandit-report.txt --format txt || true
 
-      - name: Analyze Bandit Results
+      - name: Analyse Bandit Results
         run: |
           if grep -q "Issue:" bandit-report.txt; then
             echo "Vulnerabilities found, but continuing pipeline..."
@@ -68,6 +99,7 @@ jobs:
   # Broken Access Control Tests using OWASP ZAP
   BrokenAccessControlTests:
     runs-on: ubuntu-latest
+    needs: PyTests  # Ensures tests pass before security checks
 
     steps:
       - name: Checkout code
@@ -115,10 +147,10 @@ jobs:
           path: /opt/zaproxy/zap-bac-report.html
           if-no-files-found: warn
 
-
   # Injection Vulnerabilities Tests using OWASP ZAP
   InjectionTests:
     runs-on: ubuntu-latest
+    needs: PyTests  # Ensures tests pass before security checks
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Upload Bandit Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bandit-report
           path: bandit-report.txt
@@ -141,7 +141,7 @@ jobs:
           ls -alh /opt/zaproxy
 
       - name: Upload ZAP Broken Access Control Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: zap-bac-report
           path: /opt/zaproxy/zap-bac-report.html
@@ -189,7 +189,7 @@ jobs:
           ls -alh /opt/zaproxy
 
       - name: Upload ZAP Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: zap-injection-report
           path: /opt/zaproxy/zap-injection-report.html

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,7 @@ jobs:
           flake8 . --count --show-source --statistics --output-file=flake8-report.txt || true
 
       - name: Upload Linting Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flake8-lint-report
           path: flake8-report.txt


### PR DESCRIPTION
Added a linting section to the pipeline using flake8. This service should run first, produce a linting report, then allow the other sections such as testing to run within the pipeline (linting is now set as a requirement for other pipeline sections).